### PR TITLE
CPU spec doesn't work properly on Linux

### DIFF
--- a/lib/specjour/cpu.rb
+++ b/lib/specjour/cpu.rb
@@ -1,7 +1,7 @@
 module Specjour
   module CPU
     def self.cores
-      case RUBY_PLATFORM
+      case platform
       when /darwin/
         command('hostinfo') =~ /^(\d+).+physically/
         $1.to_i
@@ -14,6 +14,10 @@ module Specjour
 
     def self.command(cmd)
       %x(#{cmd})
+    end
+
+    def self.platform
+      RUBY_PLATFORM
     end
   end
 end

--- a/spec/specjour/cpu_spec.rb
+++ b/spec/specjour/cpu_spec.rb
@@ -18,6 +18,7 @@ Load average: 0.09, Mach factor: 1.90
     end
 
     before do
+      stub(Specjour::CPU).platform.returns('darwin')
       stub(Specjour::CPU).command.returns(hostinfo)
     end
 


### PR DESCRIPTION
The spec for `Specjour::CPU` stubs the current architecture to imitate a Mac. Unfortunately, it doesn't stub it quite enough, since `RUBY_PLATFORM` is still not "darwin". This pull request puts the constant in a method and stubs it in the specs, which makes it pass on a Linux box.

It's possible to achieve the same thing by simply setting the constant, but that would issue a warning, hence the indirection.
