### PR TITLE
warning displayed on Rails 3 projects

### DIFF
--- a/lib/specjour/db_scrub.rb
+++ b/lib/specjour/db_scrub.rb
@@ -4,7 +4,6 @@ module Specjour
     begin
       require 'rake'
       if defined?(Rails) && Rails.version =~ /^3/
-        task(:environment) {}
         load 'rails/tasks/misc.rake'
         load 'active_record/railties/databases.rake'
       else


### PR DESCRIPTION
I keep seeing this warning in my logs whenever I run specjour:

WARNING: Global access to Rake DSL methods is deprecated.  Please include
    ...  Rake::DSL into classes and modules which use the Rake DSL methods.

I just removed the task(:environment) line and both my project's test suite and the specjour test suite run fine.
