### PR TITLE
Use more conservative path matching for load path

### DIFF
--- a/lib/specjour/manager.rb
+++ b/lib/specjour/manager.rb
@@ -62,7 +62,7 @@ module Specjour
         exec_cmd << " --test-paths #{test_paths.join(" ")}" if test_paths.any?
         exec_cmd << " --log" if Specjour.log?
         exec_cmd << " --quiet" if quiet?
-        load_path = $LOAD_PATH.detect {|l| l =~ %r(specjour.*/lib$)}
+        load_path = $LOAD_PATH.detect {|l| l =~ %r(specjour[^/]*/lib$)}
         bin_path = File.expand_path(File.join(load_path, "../bin"))
         Kernel.exec({"RUBYLIB" => load_path}, "#{bin_path}/specjour #{exec_cmd}")
       end


### PR DESCRIPTION
This fixes a bug where if specjour appeared anywhere in the path, it
would be matched, which is common for users of rvm maintaining this gem
with a gemset named specjour.

Example: when developing specjour, I like using a gemset named specjour. This, unfortunately, caused _any_ gem in that gemset to match.

This patch limits the path to those that have a lib folder immediately following the folder name, i.e. `specjour-1.0.1/lib` but not `~/.rvm/gems/ruby-1.9.3-p0@specjour/yard-1.0.0/lib`
