### PR TITLE
Do not try to filter specs there are none

### DIFF
--- a/lib/specjour/loader.rb
+++ b/lib/specjour/loader.rb
@@ -92,6 +92,7 @@ module Specjour
     end
 
     def filtered_examples
+      return [] unless spec_paths.any?
       ::RSpec.world.example_groups.map do |g|
         g.descendants.map do |gs|
           gs.examples


### PR DESCRIPTION
This fixes a bug where running `specjour features` would fail because RSpec had not been loaded. The error complained about RSpec.world not being available, likely due to RSpec being lazily loaded.
