### PR TITLE
Option to rerun failures

### DIFF
--- a/lib/specjour/cli.rb
+++ b/lib/specjour/cli.rb
@@ -10,6 +10,10 @@ module Specjour
       method_option :alias, :aliases => "-a", :desc => "Project name advertised to listeners"
     end
 
+    def self.rerun_option
+      method_option :rerun, :aliases => "-r", :type => :boolean, :desc => "Auto rerun failures"
+    end
+
     def self.rsync_port_option
       method_option :rsync_port, :type => :numeric, :default => 23456, :desc => "Port to use for rsync daemon"
     end
@@ -58,6 +62,7 @@ module Specjour
     end
 
     desc "dispatch [test_paths]", "Send tests to a listener"
+    rerun_option
     worker_option
     dispatcher_option
     rsync_port_option

--- a/lib/specjour/cucumber/distributed_formatter.rb
+++ b/lib/specjour/cucumber/distributed_formatter.rb
@@ -26,8 +26,7 @@ module Specjour::Cucumber
           failure.scenario_outline
         end
       end.each do |failure|
-        @failing_scenarios << format_string("cucumber " + failure.file_colon_line[2..-1], :failed) +
-                              format_string(" # Scenario: " + failure.name, :comment)
+        @failing_scenarios << OpenStruct.new(:file => failure.file_colon_line, :name => failure.name)
       end
     end
 

--- a/lib/specjour/dispatcher.rb
+++ b/lib/specjour/dispatcher.rb
@@ -115,7 +115,7 @@ module Specjour
     end
 
     def printer
-      @printer ||= Printer.new
+      @printer ||= Printer.new(@options)
     end
 
     def project_alias


### PR DESCRIPTION
Added an option to auto rerun failures locally:

```
specjour -r
```

This is good for projects with a lot of random failures.
