### PR TITLE
printer exit_status returns false if there are no reporters

### DIFF
--- a/lib/specjour/printer.rb
+++ b/lib/specjour/printer.rb
@@ -45,7 +45,7 @@ module Specjour
     end
 
     def exit_status
-      reporters.all? {|r| r.exit_status == true}
+      reporters.all? {|r| r.exit_status == true} && !reporters.empty?
     end
 
     protected


### PR DESCRIPTION
We had a situation running specjour features where the listener raised an error causing the specjour to run no tests and yet its exit_status was 0, making jenkins reports it as a successful build.

The exception was:
`/Users/telmofcosta/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/specjour-0.7.0/lib/specjour/connection.rb:46:in `block in print': private method `print' called for nil:NilClass (NoMethodError)`

Because the listener died, the socket closed, reporting "eof" to the dispatcher, making the Specjour::Printer to stop.
Since no reporter was initialised yet, Printer.exit_status retuned true because `[].all?(&:true)` evaluates to true.

I think that if the code gets to the point of asking for printer exit_status, it is safe to assume that if there are no reporters something wrong happened and thus returning false.
