### PR TITLE
Add support for rails 4

### DIFF
--- a/lib/specjour/db_scrub.rb
+++ b/lib/specjour/db_scrub.rb
@@ -31,6 +31,13 @@ module Specjour
     def connect_to_database
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.configurations = Rails.application.config.database_configuration
+
+      # support for rails 4
+      if defined?(ActiveRecord::Tasks::DatabaseTasks)
+        ActiveRecord::Tasks::DatabaseTasks.db_dir = Rails.application.config.paths["db"].first
+        ActiveRecord::Tasks::DatabaseTasks.database_configuration = Rails.application.config.database_configuration
+      end
+
       ActiveRecord::Base.establish_connection
       connection
     rescue # assume the database doesn't exist


### PR DESCRIPTION
When running specs on rails 4 I have the error below.
This change fixes the problem, I'm just not sure if it is the correct fix. At work I have a rails 4 project running specjour (specs and fixtures) with this fix and is working well.

```
Loading RSpec environment... completed in 16.598046s
Resetting database 1
NoMethodError undefined method `[]' for nil:NilClass
(...)/gems/2.1.0/gems/activerecord-4.0.13/lib/active_record/tasks/database_tasks.rb:137:in `purge'
(...)/gems/2.1.0/gems/activerecord-4.0.13/lib/active_record/railties/databases.rake:366:in `block (3 levels) in <top (required)>'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `call'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `block in execute'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `each'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `execute'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
(...)/2.1.0/monitor.rb:211:in `mon_synchronize'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:201:in `block in invoke_prerequisites'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:199:in `each'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:199:in `invoke_prerequisites'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:178:in `block in invoke_with_call_chain'
(...)/2.1.0/monitor.rb:211:in `mon_synchronize'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
(...)/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/db_scrub.rb:26:in `scrub'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/configuration.rb:66:in `block in default_after_fork'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/worker.rb:27:in `call'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/worker.rb:27:in `run_tests'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/loader.rb:30:in `block (2 levels) in start'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/fork.rb:12:in `block in fork'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/fork.rb:9:in `fork'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/fork.rb:9:in `fork'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/loader.rb:25:in `block in start'
(...)/gems/2.1.0/gems/activesupport-4.0.13/lib/active_support/core_ext/range/each.rb:7:in `each'
(...)/gems/2.1.0/gems/activesupport-4.0.13/lib/active_support/core_ext/range/each.rb:7:in `each_with_time_with_zone'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/loader.rb:24:in `start'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/cli.rb:57:in `load'
(...)/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
(...)/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
(...)/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
(...)/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/lib/specjour/cli.rb:24:in `start'
(...)/gems/2.1.0/bundler/gems/specjour-9bce2d505c9f/bin/specjour:5:in `<main>'
```
